### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ db.sqlite3
 cover/
 .coverage
 nosetests.xml
+.tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ psycopg2==2.5.2
 pyflakes==0.7.3
 selenium==2.39.0
 static==0.4
-wsgiref==0.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27, py33, py34, flake8
+skipsdist = True
+
+[testenv]
+deps = -rrequirements.txt
+commands = python manage.py test
+
+[testenv:flake8]
+commands = flake8 --exclude=migrations --ignore=E501,E225,E128,E126 django_ci_example


### PR DESCRIPTION
tox gives a simple way to handle creation of virtualenvs and
installation of necessary packages for running tests.

This allows you to call `tox` from TeamCity and not have to have a bunch
of extra build steps to prepare the virtualenvs.

As it stands in your book, the example doesn't work unless you have
Django installed in your system Python and I don't want to install it
there. I suggest adding a tox.ini and revising the book so that TeamCity
calls tox.

You might be interested in looking at how tox suggests integrating with Jenkins and then adapting that approach to TeamCity -- http://tox.readthedocs.org/en/latest/example/jenkins.html

```
$ pip install tox
...
$ tox
py27 runtests: PYTHONHASHSEED='221793339'
py27 runtests: commands[0] | python manage.py test
nosetests --verbosity=1
Creating test database for alias 'default'...
S..........
----------------------------------------------------------------------
Ran 11 tests in 0.051s

OK (SKIP=1)
Destroying test database for alias 'default'...
flake8 runtests: PYTHONHASHSEED='221793339'
flake8 runtests: commands[0] | flake8 --exclude=migrations --ignore=E501,E225,E128,E126 django_ci_example
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  flake8: commands succeeded
  congratulations :)
```
