### PR TITLE
requirements.txt: Remove wsgiref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ psycopg2==2.5.2
 pyflakes==0.7.3
 selenium==2.39.0
 static==0.4
-wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pep8==1.4.6
 psycopg2==2.5.2
 pyflakes==0.7.3
 selenium==2.39.0
-static==0.4
+static==1.1.1


### PR DESCRIPTION
`pip freeze` includes this in the output but it's more of a bug than a feature and it causes the `pip install` to fail on Python 3.

Also upgraded `static` from 0.4 to 1.1.1, because 0.4 was pulling in `wsgiref`, which causes an error when
installing on Python 3.
